### PR TITLE
add: versión del sitio como info de acerca🪛

### DIFF
--- a/buses/inicio/templates/acerca.html
+++ b/buses/inicio/templates/acerca.html
@@ -105,4 +105,8 @@
     <dd>Fabián Abarca Calderón</dd>
 </dl>
 
+<p>
+    Versión del sitio: {{ version }}
+</p>
+
 {% endblock %}

--- a/buses/inicio/views.py
+++ b/buses/inicio/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import get_object_or_404, render
 from rutas.models import Route, FeedInfo
 from datetime import datetime
+from os import popen as bash
 
 # Create your views here.
 
@@ -11,13 +12,23 @@ def index(request):
     dias = ['lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado', 'domingo']
     fecha = [dias[ahora.weekday()], ahora.day, meses[ahora.month - 1], ahora.year]
     context = {
-        'rutas': rutas, # Lista de rutas  
-        'fecha': fecha,    
+        'rutas': rutas, # Lista de rutas
+        'fecha': fecha,
     }
     return render(request, 'index.html', context)
 
 def acerca(request):
-    return render(request, 'acerca.html')
+    try:
+        # La version del sitio se puede definir como el commit que se está utilizando, así como la fecha de creación del mismo.
+        version = bash("echo $(git branch --show-current) $( git reflog --pretty='%h -> %cD' | head -n 1 | cut -f -6 --delimiter=' ' )").read()
+    except:
+        # La version no funciona para Windows, está pensada para Ubuntu Server
+        version = 'UNKNOWN'
+
+    context ={
+        'version': version,
+    }
+    return render(request, 'acerca.html', context)
 
 def gtfs(request):
     informacion = FeedInfo.objects.get(pk=1)


### PR DESCRIPTION
Muchos sitios web presentan de alguna manera en el área de información que hace tanto se actualizó el software del sitio, la versión del sitio se puede manejar con **tags** o también con **hash de commits**, esta pequeña petición a git hace que se pueda tomar el hash recortado, el branch y la fecha de este commit, con lo que siempre es posible saber que versión del sitio estamos viendo con solo ir a esta línea.

![image](https://user-images.githubusercontent.com/18200186/122355838-789dd200-cf0f-11eb-87a0-6aed6f75713f.png)

Esta información se puede colocar en cualquier parte donde se necesite, ya sea en el footer, o en acerca, ya que no es una información de valor para el consumidor promedio, más bien una herramienta para los propietarios del sitio, administradores e interesados.

![image](https://user-images.githubusercontent.com/18200186/122356059-ac78f780-cf0f-11eb-8713-fc6a41149913.png)

La línea de versión puede o no ser incluida, sin embargo antes de merge to main debe ser probada en Windows para que la página siga siendo cargada sin problemas por aquellas personas que desarrollen en dicho sistema.