### PR TITLE
rutas/fix card padding, mobile first

### DIFF
--- a/buses/rutas/templates/proximobus.html
+++ b/buses/rutas/templates/proximobus.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-sm">
     <div class="card text-center p-3 mb-5 mx-auto borde-color-ruta" style="max-width: 540px">
-      <div class="card-body">
+      <div class="card-body proxbus-card-body">
         <div class="text-center">
           <h2><span class="badge badge-dark" id="DigitalCLOCK">{% verbatim %}{{ hora }}{% endverbatim %}</span></h2>
           <h5><span class="badge badge-secondary"><span class="text-capitalize">{{ fecha.0 }}</span> {{ fecha.1 }} de {{ fecha.2 }} de {{ fecha.3 }}</span></h5>

--- a/buses/static/css/custom.css
+++ b/buses/static/css/custom.css
@@ -4,6 +4,29 @@
  *
  */
 
+.proxbus-container {
+    padding: 0;
+}
+
+.proxbus-row {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+}
+
+.proxbus-emph-row {
+    /* Emphasis column*/
+    margin-left: 0.6ch;
+    margin-right: 0.6ch;
+    background-color: #d7dde4
+}
+
+.proxbus-emph-col {
+    /* Emphasis column*/
+    padding-left: 0;
+    padding-right: 0;
+    font-size: 1.25rem;
+}
+
 .custom-sticky-top {
     position: sticky;
     top: 0px;

--- a/buses/static/css/custom.css
+++ b/buses/static/css/custom.css
@@ -4,6 +4,13 @@
  *
  */
 
+.proxbus-card-body {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+    padding-left: 0;
+    padding-right: 0;
+}
+
 .proxbus-container {
     padding: 0;
 }
@@ -15,8 +22,8 @@
 
 .proxbus-emph-row {
     /* Emphasis column*/
-    margin-left: 0.6ch;
-    margin-right: 0.6ch;
+    margin-left: 18px;
+    margin-right: 18px;
     background-color: #d7dde4
 }
 

--- a/buses/static/js/ruta_proximobus.js
+++ b/buses/static/js/ruta_proximobus.js
@@ -1,21 +1,20 @@
 ruta_app.component('proximobus', {
     props: ['route_short_name'],
     template: `
-<div class="container">
-<div class="row">
+<div class="container proxbus-container">
+
+<div class="row proxbus-row proxbus-emph-row">
 <div class="col">
-                {{ route_short_name }}
-                <i class="fas fa-arrow-circle-right color-ruta"></i> San&nbsp;José
+                {{ route_short_name }} <i class="fas fa-arrow-circle-right color-ruta"></i> San&nbsp;José
 </div>
 <div class="col">
-                  San José <i class="fas fa-arrow-circle-right color-ruta"></i>
-                  {{ route_short_name }}
+                  San José <i class="fas fa-arrow-circle-right color-ruta"></i> {{ route_short_name }}
 </div>
 </div>
 
 <!-- Primera fila -->
-<div class="row font-weight-bold">
-    <div class="col" v-if="hacia_sanjose[0]" style="font-size: 1.25rem;">
+<div class="row proxbus-row font-weight-bold">
+    <div class="col proxbus-emph-col" v-if="hacia_sanjose[0]">
         <span class="align-middle">{{ hacia_sanjose[0] }}</span>&nbsp;
         <span v-if="is_badge_visible(hacia_sanjose_ramal[0])"
             :class="['badge', 'custom-badge',
@@ -24,7 +23,7 @@ ruta_app.component('proximobus', {
     </div>
     <div class="col" v-else>No hay más buses hoy</div>
 
-    <div class="col" v-if="desde_sanjose[0]" style="font-size: 1.25rem;">
+    <div class="col proxbus-emph-col" v-if="desde_sanjose[0]">
         <span class="align-middle">{{ desde_sanjose[0] }}</span>&nbsp;
         <span v-if="is_badge_visible(desde_sanjose_ramal[0])"
             :class="['badge', 'custom-badge',
@@ -35,7 +34,7 @@ ruta_app.component('proximobus', {
 </div>
 
 <!-- Segunda fila -->
-<div class="row font-weight-bold">
+<div class="row proxbus-row font-weight-bold">
 <div class="col">
         <span v-if="hacia_sanjose[1]" class="align-middle">{{ hacia_sanjose[1] }}</span>&nbsp;
         <span v-if="is_badge_visible(hacia_sanjose_ramal[1])"
@@ -53,7 +52,7 @@ ruta_app.component('proximobus', {
 </div>
 
 <!-- Tercera fila -->
-<div class="row font-weight-bold">
+<div class="row proxbus-row font-weight-bold">
     <div class="col">
         <span v-if="hacia_sanjose[2]" class="align-middle">{{ hacia_sanjose[2] }}</span>&nbsp;
         <span v-if="is_badge_visible(hacia_sanjose_ramal[2])"

--- a/buses/static/js/ruta_proximobus.js
+++ b/buses/static/js/ruta_proximobus.js
@@ -15,40 +15,39 @@ ruta_app.component('proximobus', {
             </tr>
           </thead>
 
-<tbody>
+<tbody class="font-weight-bold">
 
 <!-- Primera fila -->
 <tr>
-    <td v-if="hacia_sanjose[0]" class="font-weight-bold lead">
+    <td v-if="hacia_sanjose[0]" style="font-size: 1.25rem;">
         <span class="align-middle">{{ hacia_sanjose[0] }}</span>&nbsp;
         <span v-if="is_badge_visible(hacia_sanjose_ramal[0])"
             :class="['badge', 'custom-badge',
             filter_badge(hacia_sanjose_ramal[0])
             ]">{{ hacia_sanjose_ramal[0] }}</span>
     </td>
-    <td v-else class="font-weight-bold">No hay más buses hoy</td>
+    <td v-else>No hay más buses hoy</td>
 
-    <td v-if="desde_sanjose[0]" class="font-weight-bold lead">
+    <td v-if="desde_sanjose[0]" style="font-size: 1.25rem;">
         <span class="align-middle">{{ desde_sanjose[0] }}</span>&nbsp;
         <span v-if="is_badge_visible(desde_sanjose_ramal[0])"
             :class="['badge', 'custom-badge',
             filter_badge(desde_sanjose_ramal[0])
             ]">{{ desde_sanjose_ramal[0] }}</span>
     </td>
-    <td v-else class="font-weight-bold">No hay más buses hoy</td>
+    <td v-else>No hay más buses hoy</td>
 </tr>
 
 <!-- Segunda fila -->
 <tr>
-    <td class="font-weight-bold">
+    <td>
         <span v-if="hacia_sanjose[1]" class="align-middle">{{ hacia_sanjose[1] }}</span>&nbsp;
         <span v-if="is_badge_visible(hacia_sanjose_ramal[1])"
             :class="['badge', 'custom-badge',
             filter_badge(hacia_sanjose_ramal[1])
             ]">{{ hacia_sanjose_ramal[1] }}</span>
     </td>
-
-    <td class="font-weight-bold">
+    <td>
         <span v-if="desde_sanjose[1]" class="align-middle">{{ desde_sanjose[1] }}</span>&nbsp;
         <span v-if="is_badge_visible(desde_sanjose_ramal[1])"
             :class="['badge', 'custom-badge',
@@ -59,15 +58,14 @@ ruta_app.component('proximobus', {
 
 <!-- Tercera fila -->
 <tr>
-    <td class="font-weight-bold">
+    <td>
         <span v-if="hacia_sanjose[2]" class="align-middle">{{ hacia_sanjose[2] }}</span>&nbsp;
         <span v-if="is_badge_visible(hacia_sanjose_ramal[2])"
             :class="['badge', 'custom-badge',
             filter_badge(hacia_sanjose_ramal[2])
             ]">{{ hacia_sanjose_ramal[2] }}</span>
     </td>
-
-    <td class="font-weight-bold">
+    <td>
         <span v-if="desde_sanjose[2]" class="align-middle">{{ desde_sanjose[2] }}</span>&nbsp;
         <span v-if="is_badge_visible(desde_sanjose_ramal[2])"
             :class="['badge', 'custom-badge',

--- a/buses/static/js/ruta_proximobus.js
+++ b/buses/static/js/ruta_proximobus.js
@@ -1,81 +1,75 @@
 ruta_app.component('proximobus', {
     props: ['route_short_name'],
     template: `
-        <table class="table table-borderless">
-          <thead class="table-secondary">
-            <tr>
-              <th>
+<div class="container">
+<div class="row">
+<div class="col">
                 {{ route_short_name }}
                 <i class="fas fa-arrow-circle-right color-ruta"></i> San&nbsp;José
-              </th>
-              <th>
+</div>
+<div class="col">
                   San José <i class="fas fa-arrow-circle-right color-ruta"></i>
                   {{ route_short_name }}
-              </th>
-            </tr>
-          </thead>
-
-<tbody class="font-weight-bold">
+</div>
+</div>
 
 <!-- Primera fila -->
-<tr>
-    <td v-if="hacia_sanjose[0]" style="font-size: 1.25rem;">
+<div class="row font-weight-bold">
+    <div class="col" v-if="hacia_sanjose[0]" style="font-size: 1.25rem;">
         <span class="align-middle">{{ hacia_sanjose[0] }}</span>&nbsp;
         <span v-if="is_badge_visible(hacia_sanjose_ramal[0])"
             :class="['badge', 'custom-badge',
             filter_badge(hacia_sanjose_ramal[0])
             ]">{{ hacia_sanjose_ramal[0] }}</span>
-    </td>
-    <td v-else>No hay más buses hoy</td>
+    </div>
+    <div class="col" v-else>No hay más buses hoy</div>
 
-    <td v-if="desde_sanjose[0]" style="font-size: 1.25rem;">
+    <div class="col" v-if="desde_sanjose[0]" style="font-size: 1.25rem;">
         <span class="align-middle">{{ desde_sanjose[0] }}</span>&nbsp;
         <span v-if="is_badge_visible(desde_sanjose_ramal[0])"
             :class="['badge', 'custom-badge',
             filter_badge(desde_sanjose_ramal[0])
             ]">{{ desde_sanjose_ramal[0] }}</span>
-    </td>
-    <td v-else>No hay más buses hoy</td>
-</tr>
+    </div>
+    <div class="col" v-else>No hay más buses hoy</div>
+</div>
 
 <!-- Segunda fila -->
-<tr>
-    <td>
+<div class="row font-weight-bold">
+<div class="col">
         <span v-if="hacia_sanjose[1]" class="align-middle">{{ hacia_sanjose[1] }}</span>&nbsp;
         <span v-if="is_badge_visible(hacia_sanjose_ramal[1])"
             :class="['badge', 'custom-badge',
             filter_badge(hacia_sanjose_ramal[1])
             ]">{{ hacia_sanjose_ramal[1] }}</span>
-    </td>
-    <td>
+    </div>
+    <div class="col">
         <span v-if="desde_sanjose[1]" class="align-middle">{{ desde_sanjose[1] }}</span>&nbsp;
         <span v-if="is_badge_visible(desde_sanjose_ramal[1])"
             :class="['badge', 'custom-badge',
             filter_badge(desde_sanjose_ramal[1])
             ]">{{ desde_sanjose_ramal[1] }}</span>
-    </td>
-</tr>
+    </div>
+</div>
 
 <!-- Tercera fila -->
-<tr>
-    <td>
+<div class="row font-weight-bold">
+    <div class="col">
         <span v-if="hacia_sanjose[2]" class="align-middle">{{ hacia_sanjose[2] }}</span>&nbsp;
         <span v-if="is_badge_visible(hacia_sanjose_ramal[2])"
             :class="['badge', 'custom-badge',
             filter_badge(hacia_sanjose_ramal[2])
             ]">{{ hacia_sanjose_ramal[2] }}</span>
-    </td>
-    <td>
+    </div>
+    <div class="col">
         <span v-if="desde_sanjose[2]" class="align-middle">{{ desde_sanjose[2] }}</span>&nbsp;
         <span v-if="is_badge_visible(desde_sanjose_ramal[2])"
             :class="['badge', 'custom-badge',
             filter_badge(desde_sanjose_ramal[2])
             ]">{{ desde_sanjose_ramal[2] }}</span>
-    </td>
-</tr>
-
-</tbody>
-</table>
+    </div>
+</div>
+</div>
 `,
     data: function () {
         return {


### PR DESCRIPTION
Debido a que hay muchas clases anidadas el CSS termina con padding más grande que la pantalla y el widget de próximo bus siempre termina desordenado y se ve muy mal en el celular porque a veces una hora está en una línea otras dos o inclusive tres, entonces se realizan algunas correciones con tal de hacerlo mobile first
![image](https://user-images.githubusercontent.com/18200186/125670846-bcc6bcb1-c9e0-4256-8acd-a5e66941c1dc.png)

Primero se sustituye la tabla por contenedores de bt porque las tablas se usaban en estilos antes de la existencia del flex, son muy poco responsive y por lo general los expertos no recomiendan usarlas, ya que se incluyó bt mejor usar las clases que ya ellos diseñaron.

Quitar los paddings internos por medio de clases propias del proyecto y dejar un solo padding del card automático.

![image](https://user-images.githubusercontent.com/18200186/125670794-fb09ab6a-4bb3-48eb-ba3c-a7134ce79a34.png)

Se podría considerar hacer un media query para incluir una línea entre columnas para aquellos celulares que sean muy angostos, aunque en este momento las columnas respetan el padding anterior y no se tocan pero se puede hacer para más facilidad, solo en la versión mobile, ya que en desk no es necesario