### PR TITLE
Compartir estilo de los otros widget

### DIFF
--- a/buses/rutas/templates/ruta.html
+++ b/buses/rutas/templates/ruta.html
@@ -316,13 +316,20 @@ NOTA: TODO: Este div no tiene terminación, hay que hacer que cierre consistente
 <section id="mapa">
 
     <hr>
-    <h2><i class="fas fa-map color-ruta"></i> Mapa de la ruta</h2>
-    {% if route.short_name == 'Acosta' %}
-    <mapa-acosta></mapa-acosta>
-    {% else %}
-    <mapa-sangabriel></mapa-sangabriel>
-    {% endif %}
+    <h2><i class="fas fa-map color-ruta"></i> Mapa de la ruta {{route.short_name}}</h2>
 
+    <div style="max-width: 580px;" class="card text-center p-3 mb-5 mx-auto borde-color-ruta">
+
+        {% if route.short_name == 'Acosta' %}
+        <mapa-acosta></mapa-acosta>
+
+        {% else %}
+        <mapa-sangabriel></mapa-sangabriel>
+
+        {% endif %}
+    </div>
+    <br/>
+    <br/>
 </section>
 
 <!-- Paradas autorizadas -->

--- a/buses/static/js/ruta_acosta.js
+++ b/buses/static/js/ruta_acosta.js
@@ -1,13 +1,10 @@
 ruta_app.component("mapa-acosta", {
-  /*html*/
-  template: `
+    template: /*html*/
+    `
             <div class="container text-center">
-                
                 <div class="row">
-                    <div class="col-sm-1">
-                    </div>
-                    <div class="col-sm-10">
-                        <div class="btn-group btn-group-toggle" data-toggle="buttons">
+                    <div class="col">
+                        <div class="btn-group btn-group-toggle d-flex" data-toggle="buttons">
                             <label class="btn btn-xs btn-primary active">
                             <input type="radio"  v-on:click="updateSelectedRoundTripRoute(0)" checked> San&nbsp;Luis
                             </label>
@@ -19,11 +16,9 @@ ruta_app.component("mapa-acosta", {
                             </label>
                         </div>
                     </div>
-                    <div class="col-sm-1">
-                    </div>
                 </div>
-                <br/>            
-                <div class="col-md-12">
+                <br/>
+                <div class="col">
                     <div class="row">
                         <div class="col-2">
                         </div>
@@ -48,7 +43,7 @@ ruta_app.component("mapa-acosta", {
                                 {{currentRoundTripRoute.toRouteName}}
                             </p>
                         </div>
-                        <div class="col-2">                                
+                        <div class="col-2">
                         </div>
                     </div>
                 </div>
@@ -60,10 +55,7 @@ ruta_app.component("mapa-acosta", {
                         <div id="mapId" class="map map-home" style="margin:auto; height:400px; max-width: 540px;"></div>
                     </div>
                 </div>
-                <br/>
-
-            </div>
-            <br/>`,
+`,
   data() {
     return {
       center: [45.51, -122.68],

--- a/buses/static/js/ruta_sangabriel.js
+++ b/buses/static/js/ruta_sangabriel.js
@@ -1,6 +1,6 @@
 ruta_app.component('mapa-sangabriel', {
-    template:/*html*/ 
-            `
+    template: /*html*/
+    `
             <div class="container text-center">
             <div class="row">
                 <div class="col-md-2">
@@ -36,10 +36,12 @@ ruta_app.component('mapa-sangabriel', {
                 </div>
             </div>
         </div>
-            <div id="mapId" class="map map-home" style="margin:auto; height:400px; max-width: 540px;"></div>
-                <br/>
-
-            <br/>`,
+            <div class="row">
+                <div class="col-12">
+                    <div id="mapId" class="map map-home" style="margin:auto; height:400px; max-width: 540px;"></div>
+                </div>
+            </div>
+`,
     data() {
         return {
             center: [45.51, -122.68],


### PR DESCRIPTION
Un par de aportes de estilo para que el _widget_ de mapa comparta el estilo del de próximo bus.

![image](https://user-images.githubusercontent.com/18200186/133925062-718e8092-07da-46ec-b907-ad49e3a672bd.png)
![image](https://user-images.githubusercontent.com/18200186/133925100-8fbf9ed5-e5be-4e29-9459-f1cdd4e6fdb9.png)

Quizás redondear las esquinas del mapa propiamente pueda mejorar el efecto del _widget_
por mientras lo dejo aquí mientras _main_ se recupera