### PR TITLE
Script descarga de forma automática imagen de restricción de fuente MOPT

### DIFF
--- a/bash/restric_mopt_img_download.sh
+++ b/bash/restric_mopt_img_download.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+IMAGE_URL="$(
+    wget -O - --quiet --no-check-certificate 'https://www.mopt.go.cr/wps/portal/Home/informacionrelevante/restriccion/' |
+        grep '<img[^>]*[^>]*>' -o |
+        grep 'restricci[[=o=]]n' -i |
+        grep -o 'src="[^"]*' |
+        sed 's/src="/https:\/\/www.mopt.go.cr/'
+         )"
+
+echo "Restricción imagen URL: $IMAGE_URL"
+
+wget --quiet --no-check-certificate -O restric.png "$IMAGE_URL"
+
+exit 0


### PR DESCRIPTION
Pequeño script(bot) que ingresa a la página del MOPT referente a la restricción vehicular y obtiene la URL de la imagen, de esta manera se puede incrustrar de manera automática dicha imagen o descargarla por parte del servidor sin intervención humana.

Esta primera versión está en Bash, falta por hacer integrarla con Python para que este sea quién coloque siempre la URL de la imagen más actualizada.