### PR TITLE
Implementación resolución automática de URL calendario restricciones

### DIFF
--- a/buses/inicio/templates/covid19.html
+++ b/buses/inicio/templates/covid19.html
@@ -49,15 +49,11 @@
 <p>Información de la <a href="nZDBCoJAEIafxqszaZp2c4m0EjRJtL2Ehq2CuqKWr5_UJU0qmtsM3zf8M0AhBFpGt4xFbcbLKO_7I1VPG9fE2W6OtmnpKhqKR4i0tyTnoEIwAlRvhYZu28raQVlbINBffByUgcSTiIxoOtI__uum7z4dIe8XPIBPESeAQYYtUJbz">página</a> del Ministerio de Obras Pública y Transportes:</p>
 
 <div id="carouselExampleControls" class="carousel slide" data-ride="carousel">
+    {# Esta variable resuelve desde el servidor la dirección de la imagen calendario de restricciones restric_calendar_url #}
     <div class="carousel-inner">
       <div class="carousel-item active">
-        <img class="d-block w-100" src="{% static 'img/restriccion-agosto.jpeg' %}" alt="10 al 25 de julio de 2021">
+          <img class="d-block w-100" src="{{ restric_calendar_url }}">
       </div>
-      <!--
-      <div class="carousel-item">
-        <img class="d-block w-100" src="{% static 'img/restriccion-julio-agosto.jpeg' %}" alt="26 de julio al 8 agosto de 2021">
-      </div>
-      -->
     </div>
 
     <a class="carousel-control-prev" href="#carouselExampleControls" role="button" data-slide="prev">

--- a/buses/inicio/views.py
+++ b/buses/inicio/views.py
@@ -2,8 +2,27 @@ from django.shortcuts import get_object_or_404, render
 from rutas.models import Route, FeedInfo, FareAttribute
 from datetime import datetime
 from os import popen as bash
+import requests, re
 
-# Create your views here.
+## Util functions
+def get_restriccion_calendar_url_from_mopt():
+    url = 'https://www.mopt.go.cr/wps/portal/Home/informacionrelevante/restriccion/'
+    response = requests.get(
+        url,
+        allow_redirects=True,
+        verify=False)
+
+    html = str(response.content)
+    images_url_list = re.findall('<img[^>]*[^>]*>', html)
+    restriccion_image_url = ''
+
+    for element in images_url_list:
+        if re.match('.*restricci.{2,16}sanitaria.*', element, flags=re.IGNORECASE):
+            restriccion_image_url = re.search('src="[^"]*', element)
+
+    return restriccion_image_url.group(0).replace('src="', 'https://www.mopt.go.cr')
+
+## Create your views here.
 
 def index(request):
     rutas = Route.objects.all()
@@ -49,7 +68,10 @@ def gtfs(request):
     return render(request, 'gtfs.html', context)
 
 def covid19(request):
-    return render(request, 'covid19.html')
+    context = {
+        'restric_calendar_url': get_restriccion_calendar_url_from_mopt()
+    }
+    return render(request, 'covid19.html', context)
 
 def presentacion(request):
     return render(request, 'presentacion.html')


### PR DESCRIPTION
### Hardcoded/soft conf en página admin:
Haciendo uso de la función desarrollada con REGEX en Bash/Python se implementa en la vista de información sobre el Covid19 la resolución automática de la URL del calendario desde la fuente prestada por el MOPT.

En el caso anterior teníamos lo siguiente:
![image](https://user-images.githubusercontent.com/18200186/133999635-c7221aa3-8a8b-428c-8213-bf96b13e6375.png)
El calendario se observa en el sitio pero la imagen es local estática, por lo cual requiere una intervención continua por parte de codificadores.
![image](https://user-images.githubusercontent.com/18200186/133999847-007c72b5-0de1-463b-a6d8-14c3d20924c7.png)
### Con auto-resolv:
![image](https://user-images.githubusercontent.com/18200186/134000016-58331953-73cc-4347-85dc-da1a3c016479.png)
La página muestra siempre el calendario actual posteado en la web institucional, la información está disponible tan pronto como se actualiza por parte del ente. Es decir, al postear allá ya se visualizará en el sitio de buses también sin ningún cambio en el código o el sitio de admin.
![image](https://user-images.githubusercontent.com/18200186/134000254-439371eb-d6e9-4172-b4ee-9acd569bc569.png)
La URL que se resuelve es incrustada directamente desde el server de estáticos del MOPT por lo que descargar la imagen para introducirla en el repo puede evitarse.
![image](https://user-images.githubusercontent.com/18200186/134001048-814ae74c-3000-4c37-b34f-302ddf8c1aaf.png)
La URL cambiará cada vez que el WordPress del MOPT introduzca otra imagen, pero este código insertará la nueva URL en el template HTML.