### PR TITLE
Utilizar Vue para mostrar pequeñas ventadas de información en la sección de paradas.

### DIFF
--- a/buses/rutas/templates/ruta.html
+++ b/buses/rutas/templates/ruta.html
@@ -372,9 +372,22 @@ NOTA: TODO: Este div no tiene terminación, hay que hacer que cierre consistente
                 {% for parada in paradas_desde_0 %}
                 <li class="step-item">
                     <div class="step-content-wrapper">
-                        <span class="step-icon step-icon-xs step-icon-soft-secondary"><i class="fas fa-arrow-right"></i></span>
+                        <span @click="showHideStopInfo('{{parada.stop_id}}', $event)" class="step-icon step-icon-xs step-icon-soft-secondary"><i :class="['fas', 'fa-arrow-right']"></i></span>
                         <div class="step-content">
-                            <p class="step-text">{{ parada.name }}</p>
+
+                            <p class="step-text" id="short_name_stop_id_{{parada.stop_id}}">{{ parada.name }}</p>
+{# begin stop card #}
+                            <div class="card card-bordered mx-auto" id="info_stop_id_{{parada.stop_id}}" style="max-width: 540px;" hidden>
+                                <div class="card-body">
+                                    <h5 class="card-title">{{ parada.name }}</h5>
+                                    <ol class="fa-ul">
+                                        <!-- <li><span class="fa-li"><i class="far fa-map"></i></span>{{ parada.lon }} {{ parada.lat }}</li> --> {# FIXME la descripción no está para todas las paradas #}
+                                        <!-- <li><span class="fa-li"><i class="fas fa-location-arrow"></i></span>{{ parada.desc }}.</li> --> {# FIXME la descripción no está para todas las paradas#}
+                                        <li><span class="fa-li"><i class="fab fa-waze"></i></span><a href="https://ul.waze.com/ul?ll={{ parada.lat|safe }}%2C{{ parada.lon|safe }}&navigate=yes&zoom=17">Dirección en Waze</a></li>
+                                    </ol>
+                                </div>
+                            </div>
+{# end stop card #}
                         </div>
                     </div>
                 </li>

--- a/buses/static/js/ruta_main.js
+++ b/buses/static/js/ruta_main.js
@@ -31,6 +31,30 @@ const ruta_app = Vue.createApp({
                     }, 1500);
                 });
         },
+        showHideStopInfo(stop_id, event){
+
+            // Definir si se hizo click sobre la flecha o el contenedor circular
+            let target = event.target;
+            if (event.target.childElementCount) target = event.target.childNodes[0];
+
+            // Cambiar la dirección de la flecha
+            if ( target.classList.contains('fa-arrow-down')){
+                target.classList.add("fa-arrow-right");
+                target.classList.remove("fa-arrow-down");
+            } else {
+                target.classList.add("fa-arrow-down");
+                target.classList.remove("fa-arrow-right");
+            }
+
+            // Mostrar u ocultar la ficha informativa según el caso
+            if (document.getElementById('short_name_stop_id_'+stop_id).hidden){
+                document.getElementById('short_name_stop_id_'+stop_id).hidden = false;
+                document.getElementById('info_stop_id_'+stop_id).hidden = true;
+            }else {
+                document.getElementById('short_name_stop_id_'+stop_id).hidden = true;
+                document.getElementById('info_stop_id_'+stop_id).hidden = false;
+            }
+        },
     },
     mounted () {
         setInterval(() => { // Lógica de la aplicación HORADIGITAL


### PR DESCRIPTION
La idea es como se muestra en el vídeo, hacer uso de Vue para dinamizar la información en la sección de paradas.

Dentro de la ficha informativa se encuentra también la descripcción de la parada así como la dirección, sin embargo como estos espacios no están definidos actualmente en la base de datos lo único que se muestra en la URL de la geolocalización en Waze.

https://user-images.githubusercontent.com/18200186/134819459-c69c93f8-17bf-4c72-9d2c-1f7c3cfb7cdf.mp4

- Es necesario agregar la descripción de las paradas al GTFS y a la base de datos para que la ficha tenga más riqueza de datos.
- En caso de usar este código agregar todos los elementos a la lista ya que solo la primera lista tiene este estilo.