### PR TITLE
chg: simplificar proxbus html usando CSS pseudo elem

### DIFF
--- a/buses/rutas/static/rutas/css/proximos_buses.css
+++ b/buses/rutas/static/rutas/css/proximos_buses.css
@@ -1,0 +1,91 @@
+.time-badge-turrujal,
+.time-badge-sanluis,
+.time-badge-acosta,
+.time-badge-jorco,
+.time-badge-sangabriel {
+    min-width: 12ch;
+    display: inline-block;
+    vertical-align: middle !important;
+}
+
+.time-badge-turrujal::after, .time-badge-turrujal::before,
+.time-badge-sanluis::after, .time-badge-sanluis::before,
+.time-badge-acosta::after, .time-badge-acosta::before,
+.time-badge-jorco::after, .time-badge-jorco::before,
+.time-badge-sangabriel::after, .time-badge-sangabriel::before {
+    display: inline-block;
+    margin-left: 1.7ch;
+    margin-right: 1.7ch;
+	  padding: .275rem .5em;
+	  font-size: 75%;
+	  font-weight: 600;
+	  line-height: 1;
+	  text-align: center;
+	  white-space: nowrap;
+	  vertical-align: baseline;
+	  border-radius: .3125rem;
+	  transition: all .2s ease-in-out;
+	  width: 4.2ch;
+}
+
+
+.prox_derecha .time-badge-turrujal::after,
+.prox_izquierda .time-badge-turrujal::after {
+    content: 'TU';
+	  background-color: #FF4500;
+	  color: white;
+}
+
+.prox_derecha .time-badge-sanluis::after,
+.prox_izquierda .time-badge-sanluis::after {
+    content: 'SL';
+	  background-color: #FFA500;
+	  color: black;
+}
+
+.prox_derecha .time-badge-acosta::after,
+.prox_izquierda .time-badge-acosta::after {
+    content: 'AC';
+	  color: #fff;
+	  background-color: #71869d;
+}
+
+.prox_derecha .time-badge-jorco::after,
+.prox_izquierda .time-badge-jorco::after {
+    content: 'JO';
+	  color: #fff;
+	  background-color: #71869d;
+}
+
+.prox_derecha .time-badge-sangabriel::after,
+.prox_izquierda .time-badge-sangabriel::after {
+    /* content: 'SG'; */
+	  background-color: #FF4500;
+	  color: white;
+}
+
+.prox_izquierda {
+    display: inline-grid;
+    justify-content: center;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    padding-right: 0;
+    padding-left: 0;
+
+    border-right-width: 1px;
+	  border-right-style: solid;
+    border-right-color: #d7dde4;
+}
+
+.prox_derecha {
+    display: inline-grid;
+    justify-content: center;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    padding-right: 0;
+    padding-left: 0;
+
+    border-left-width: 1px;
+	  border-left-style: solid;
+    border-left-color: #d7dde4;
+}

--- a/buses/rutas/templates/ruta.html
+++ b/buses/rutas/templates/ruta.html
@@ -24,6 +24,8 @@
             color: #0400FF;
         }
     </style>
+
+    <link rel="stylesheet" href="{% static 'rutas/css/proximos_buses.css' %}">
 {% endblock %}
 
 {% block content %}

--- a/buses/static/css/custom.css
+++ b/buses/static/css/custom.css
@@ -15,11 +15,6 @@
     padding: 0;
 }
 
-.proxbus-row {
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
-}
-
 .proxbus-emph-row {
     /* Emphasis column*/
     margin-left: 18px;
@@ -29,8 +24,6 @@
 
 .proxbus-emph-col {
     /* Emphasis column*/
-    padding-left: 0;
-    padding-right: 0;
     font-size: 1.25rem;
 }
 
@@ -45,10 +38,6 @@
 
 .custom-vertical-space {
     min-height: 10ch;
-}
-
-.custom-badge {
-    min-width: 4.2ch;
 }
 
 #content-desktop {display: block;}

--- a/buses/static/js/ruta_proximobus.js
+++ b/buses/static/js/ruta_proximobus.js
@@ -14,59 +14,35 @@ ruta_app.component('proximobus', {
 
 <!-- Primera fila -->
 <div class="row proxbus-row font-weight-bold">
-    <div class="col proxbus-emph-col" v-if="hacia_sanjose[0]">
-        <span class="align-middle">{{ hacia_sanjose[0] }}</span>&nbsp;
-        <span v-if="is_badge_visible(hacia_sanjose_ramal[0])"
-            :class="['badge', 'custom-badge',
-            filter_badge(hacia_sanjose_ramal[0])
-            ]">{{ hacia_sanjose_ramal[0] }}</span>
+    <div class="col proxbus-emph-col prox_izquierda" v-if="hacia_sanjose[0]">
+      <div v-show="hacia_sanjose[0]" :class="[filter_badge(hacia_sanjose_ramal[0])]">{{ hacia_sanjose[0] }}</div>
     </div>
-    <div class="col" v-else>No hay más buses hoy</div>
+    <div class="col prox_izquierda" v-else>No hay más buses hoy</div>
 
-    <div class="col proxbus-emph-col" v-if="desde_sanjose[0]">
-        <span class="align-middle">{{ desde_sanjose[0] }}</span>&nbsp;
-        <span v-if="is_badge_visible(desde_sanjose_ramal[0])"
-            :class="['badge', 'custom-badge',
-            filter_badge(desde_sanjose_ramal[0])
-            ]">{{ desde_sanjose_ramal[0] }}</span>
+    <div class="col proxbus-emph-col prox_derecha" v-if="desde_sanjose[0]">
+      <div v-show="desde_sanjose[0]" :class="[filter_badge(desde_sanjose_ramal[0])]">{{ desde_sanjose[0] }}</div>
     </div>
-    <div class="col" v-else>No hay más buses hoy</div>
+    <div class="col prox_derecha" v-else>No hay más buses hoy</div>
 </div>
 
 <!-- Segunda fila -->
-<div class="row proxbus-row font-weight-bold">
-<div class="col">
-        <span v-if="hacia_sanjose[1]" class="align-middle">{{ hacia_sanjose[1] }}</span>&nbsp;
-        <span v-if="is_badge_visible(hacia_sanjose_ramal[1])"
-            :class="['badge', 'custom-badge',
-            filter_badge(hacia_sanjose_ramal[1])
-            ]">{{ hacia_sanjose_ramal[1] }}</span>
-    </div>
-    <div class="col">
-        <span v-if="desde_sanjose[1]" class="align-middle">{{ desde_sanjose[1] }}</span>&nbsp;
-        <span v-if="is_badge_visible(desde_sanjose_ramal[1])"
-            :class="['badge', 'custom-badge',
-            filter_badge(desde_sanjose_ramal[1])
-            ]">{{ desde_sanjose_ramal[1] }}</span>
-    </div>
+<div v-show="hacia_sanjose[1] || desde_sanjose[1]" class="row proxbus-row font-weight-bold">
+  <div class='col prox_izquierda'>
+    <div v-show="hacia_sanjose[1]" :class="[filter_badge(hacia_sanjose_ramal[1])]">{{ hacia_sanjose[1] }}</div>
+  </div>
+  <div class='col prox_derecha'>
+    <div v-show="desde_sanjose[1]" :class="[filter_badge(desde_sanjose_ramal[1])]">{{ desde_sanjose[1] }}</div>
+  </div>
 </div>
 
 <!-- Tercera fila -->
-<div class="row proxbus-row font-weight-bold">
-    <div class="col">
-        <span v-if="hacia_sanjose[2]" class="align-middle">{{ hacia_sanjose[2] }}</span>&nbsp;
-        <span v-if="is_badge_visible(hacia_sanjose_ramal[2])"
-            :class="['badge', 'custom-badge',
-            filter_badge(hacia_sanjose_ramal[2])
-            ]">{{ hacia_sanjose_ramal[2] }}</span>
-    </div>
-    <div class="col">
-        <span v-if="desde_sanjose[2]" class="align-middle">{{ desde_sanjose[2] }}</span>&nbsp;
-        <span v-if="is_badge_visible(desde_sanjose_ramal[2])"
-            :class="['badge', 'custom-badge',
-            filter_badge(desde_sanjose_ramal[2])
-            ]">{{ desde_sanjose_ramal[2] }}</span>
-    </div>
+<div v-show="hacia_sanjose[2] || desde_sanjose[2]" class="row proxbus-row font-weight-bold">
+  <div class='col prox_izquierda'>
+    <div v-show="hacia_sanjose[2]" :class="[filter_badge(hacia_sanjose_ramal[2])]">{{ hacia_sanjose[2] }}</div>
+  </div>
+  <div class='col prox_derecha'>
+    <div v-show="desde_sanjose[2]" :class="[filter_badge(desde_sanjose_ramal[2])]">{{ desde_sanjose[2] }}</div>
+  </div>
 </div>
 </div>
 `,
@@ -86,11 +62,11 @@ ruta_app.component('proximobus', {
             return false;
         },
         filter_badge (ramal){
-            if (ramal == 'SG') return 'invisible';
-            if (ramal == 'AC') return 'badge-secondary';
-            if (ramal == 'SL') return 'fondo-color-sanluis';
-            if (ramal == 'TU') return 'fondo-color-turrujal';
-            if (ramal == 'JO') return 'badge-secondary';
+            if (ramal == 'SG') return 'time-badge-sangabriel';
+            if (ramal == 'AC') return 'time-badge-acosta';
+            if (ramal == 'SL') return 'time-badge-sanluis';
+            if (ramal == 'TU') return 'time-badge-turrujal';
+            if (ramal == 'JO') return 'time-badge-jorco';
             return '';
         },
         updateProximoBus: function(){


### PR DESCRIPTION
Utilizar CSS para eliminar la excesiva cantidad de HTML amañado, esto simplifica la sección y la vuelve más eficiente.

![image](https://user-images.githubusercontent.com/18200186/138584784-7208d940-4f1d-4d49-9f9b-4b9869078d19.png)

Los badges tienen un mismo grosor y tamaño excepto por el de primera línea que tiene énfasis, están alineados entre líneas siempre y cuando el ancho de la pantalla lo permita.

![image](https://user-images.githubusercontent.com/18200186/138584803-a397c1d1-5afe-48f6-811c-2cee225bfc2c.png)

El badge de ramal ahora es 100% estilo, ya no es más un _span_, desde el CSS es posible decirle de que lado debe estár según la columna.

![image](https://user-images.githubusercontent.com/18200186/138584886-1f27a367-cf5a-4e22-850c-f883a465ce83.png)

Conforme se acaba el horario la líneas que no contienen nada desaparecen para reducir el espacio utilizado.

![image](https://user-images.githubusercontent.com/18200186/138584962-c5d22d90-64af-4a97-9d21-8db57198b137.png)

![image](https://user-images.githubusercontent.com/18200186/138585007-3887beac-c0d2-45d2-b640-cd8f77220cdd.png)

