### PR TITLE
Contacto - Frontend para el formulario de contacto

### DIFF
--- a/buses/contacto/form.py
+++ b/buses/contacto/form.py
@@ -13,6 +13,7 @@ asuntos = [
 class Formulario(forms.Form):
     nombre = forms.CharField(required=True)
     email = forms.EmailField(required=True)
+    telefono = forms.CharField(required=False)
     asunto = forms.CharField(required=True,
                              label='¿Cuál es el motivo de consulta?',
                              widget=forms.Select(choices=asuntos)

--- a/buses/contacto/static/contacto/css/formulario.css
+++ b/buses/contacto/static/contacto/css/formulario.css
@@ -1,0 +1,9 @@
+.form_alerts {
+    margin-top: 1.2ch;
+    transition-duration: 0.3s;
+}
+
+.form_alerts_hide {
+    overflow-x: hidden;
+    height: 0;
+}

--- a/buses/contacto/static/contacto/js/main_contacto.js
+++ b/buses/contacto/static/contacto/js/main_contacto.js
@@ -64,7 +64,7 @@ let validarInputCorreo = (event) => {
   } else if (
     // Si el correo tiene un @
     element.value.split("@").length == 2 &&
-    element.value.split("@")[1].split(".").length > 2
+    element.value.split("@")[1].split(".").length > 1
   ) {
     element.classList.remove("is-invalid");
     element.classList.add("is-valid");

--- a/buses/contacto/static/contacto/js/main_contacto.js
+++ b/buses/contacto/static/contacto/js/main_contacto.js
@@ -43,6 +43,7 @@ let validarInputNombre = ({target}) => {
 let validarInputTelefono = ({target}) => {
   // Delete multiple spaces keep only one
   target.value = target.value.replace(/ * /g, ' ');
+  target.value = target.value.replace(/-*-/g, '-');
 
   if (!target.value.length) {
     target.classList.remove("is-valid");

--- a/buses/contacto/static/contacto/js/main_contacto.js
+++ b/buses/contacto/static/contacto/js/main_contacto.js
@@ -12,80 +12,96 @@ let form_telefono = document.getElementById("id_telefono");
 let form_mensaje = document.getElementById("id_mensaje");
 let form_email = document.getElementById("id_email");
 
+// Clear form on browser refresh
+form_nombre.value = '';
+form_telefono.value = '';
+form_mensaje.value = '';
+form_email.value = '';
+
 ////////////////////////////////////////////////////////////////
 ////////////////// Definir los métodos para cada evento ////////
 ////////////////////////////////////////////////////////////////
 
-let validarInputNombre = (event) => {
+let validarInputNombre = ({target}) => {
   // Verificar un tamaño mínimo
-  if (!event.target.value.length) {
-    event.target.classList.remove("is-valid");
-    event.target.classList.remove("is-invalid");
-  } else if (event.target.value.length < 2) {
-    event.target.classList.add("is-invalid");
-    event.target.classList.remove("is-valid");
+
+  // Delete multiple spaces keep only one
+  target.value = target.value.replace(/ * /g, ' ');
+
+  if (!target.value.length) {
+    target.classList.remove("is-valid");
+    target.classList.remove("is-invalid");
+  } else if (target.value.length < 2) {
+    target.classList.add("is-invalid");
+    target.classList.remove("is-valid");
   } else {
-    event.target.classList.add("is-valid");
-    event.target.classList.remove("is-invalid");
+    target.classList.add("is-valid");
+    target.classList.remove("is-invalid");
   }
 };
 
-let validarInputTelefono = (event) => {
-  let element = event.target;
-  if (!element.value.length) {
-    element.classList.remove("is-valid");
-    element.classList.remove("is-invalid");
+let validarInputTelefono = ({target}) => {
+  // Delete multiple spaces keep only one
+  target.value = target.value.replace(/ * /g, ' ');
+
+  if (!target.value.length) {
+    target.classList.remove("is-valid");
+    target.classList.remove("is-invalid");
   } else if (
     // Si no tiene un + el número se observa si es un entero
-    element.value.split("+").length == 1 &&
-    Number.isInteger(Number(element.value.replace(/[- ]/g, "")))
+    target.value.split("+").length == 1 &&
+    Number.isInteger(Number(target.value.replace(/[- ]/g, "")))
   ) {
-    element.classList.remove("is-invalid");
-    element.classList.add("is-valid");
+    target.classList.remove("is-invalid");
+    target.classList.add("is-valid");
   } else if (
     // Si tiene un + se toma unicamente el número se observa si es un entero
-    element.value.split("+").length == 2 &&
-    Number.isInteger(Number(element.value.split("+")[1].replace(/[- ]/g, "")))
+    target.value.split("+").length == 2 &&
+    Number.isInteger(Number(target.value.split("+")[1].replace(/[- ]/g, "")))
   ) {
-    element.classList.remove("is-invalid");
-    element.classList.add("is-valid");
+    target.classList.remove("is-invalid");
+    target.classList.add("is-valid");
   } else {
     // Si no es un número entero entonces es inválido
-    element.classList.remove("is-valid");
-    element.classList.add("is-invalid");
+    target.classList.remove("is-valid");
+    target.classList.add("is-invalid");
   }
 };
 
-let validarInputCorreo = (event) => {
-  let element = event.target;
-  if (!element.value.length) {
-    element.classList.remove("is-valid");
-    element.classList.remove("is-invalid");
+let validarInputCorreo = ({target}) => {
+  // Delete spaces at the end
+  target.value = target.value.replace(/ *$/, '');
+
+  if (!target.value.length) {
+    target.classList.remove("is-valid");
+    target.classList.remove("is-invalid");
   } else if (
     // Si el correo tiene un @
-    element.value.split("@").length == 2 &&
-    element.value.split("@")[1].split(".").length > 1
+    target.value.split(" ").length == 1 && // no spaces in text
+    target.value.split("@").length == 2 && // no more than one @
+    target.value.split("@")[1].split(".").length > 1 && // at least one dot
+    target.value.length < 60 // Max email length
   ) {
-    element.classList.remove("is-invalid");
-    element.classList.add("is-valid");
+    target.classList.remove("is-invalid");
+    target.classList.add("is-valid");
   } else {
     // Si el correo no tiene @
-    element.classList.remove("is-valid");
-    element.classList.add("is-invalid");
+    target.classList.remove("is-valid");
+    target.classList.add("is-invalid");
   }
 };
 
-let validarInputMensaje = (event) => {
+let validarInputMensaje = ({target}) => {
   // Verificar que no exceda los 500 characters
-  if (!event.target.value.length) {
-    event.target.classList.remove("is-valid");
-    event.target.classList.remove("is-invalid");
-  } else if (event.target.value.length > 500) {
-    event.target.classList.add("is-invalid");
-    event.target.classList.remove("is-valid");
+  if (!target.value.length) {
+    target.classList.remove("is-valid");
+    target.classList.remove("is-invalid");
+  } else if (target.value.length > 500) {
+    target.classList.add("is-invalid");
+    target.classList.remove("is-valid");
   } else {
-    event.target.classList.add("is-valid");
-    event.target.classList.remove("is-invalid");
+    target.classList.add("is-valid");
+    target.classList.remove("is-invalid");
   }
 };
 

--- a/buses/contacto/static/contacto/js/main_contacto.js
+++ b/buses/contacto/static/contacto/js/main_contacto.js
@@ -1,0 +1,188 @@
+// Contact form page JS, type="module", private scope, vanilla JS
+
+////////////////////////////////////////////////////////////////
+////////////////// Elementos del formulario a utilizar /////////
+////////////////////////////////////////////////////////////////
+
+// Se hace query del formulario
+let formulario = document.querySelector("form");
+let form_alerts = formulario.getElementsByClassName("form_alerts")[0]; // .childNodes[1];
+let form_nombre = document.getElementById("id_nombre");
+let form_telefono = document.getElementById("id_telefono");
+let form_mensaje = document.getElementById("id_mensaje");
+let form_email = document.getElementById("id_email");
+
+////////////////////////////////////////////////////////////////
+////////////////// Definir los métodos para cada evento ////////
+////////////////////////////////////////////////////////////////
+
+let validarInputNombre = (event) => {
+  // Verificar un tamaño mínimo
+  if (!event.target.value.length) {
+    event.target.classList.remove("is-valid");
+    event.target.classList.remove("is-invalid");
+  } else if (event.target.value.length < 2) {
+    event.target.classList.add("is-invalid");
+    event.target.classList.remove("is-valid");
+  } else {
+    event.target.classList.add("is-valid");
+    event.target.classList.remove("is-invalid");
+  }
+};
+
+let validarInputTelefono = (event) => {
+  let element = event.target;
+  if (!element.value.length) {
+    element.classList.remove("is-valid");
+    element.classList.remove("is-invalid");
+  } else if (
+    // Si no tiene un + el número se observa si es un entero
+    element.value.split("+").length == 1 &&
+    Number.isInteger(Number(element.value.replace(/[- ]/g, "")))
+  ) {
+    element.classList.remove("is-invalid");
+    element.classList.add("is-valid");
+  } else if (
+    // Si tiene un + se toma unicamente el número se observa si es un entero
+    element.value.split("+").length == 2 &&
+    Number.isInteger(Number(element.value.split("+")[1].replace(/[- ]/g, "")))
+  ) {
+    element.classList.remove("is-invalid");
+    element.classList.add("is-valid");
+  } else {
+    // Si no es un número entero entonces es inválido
+    element.classList.remove("is-valid");
+    element.classList.add("is-invalid");
+  }
+};
+
+let validarInputCorreo = (event) => {
+  let element = event.target;
+  if (!element.value.length) {
+    element.classList.remove("is-valid");
+    element.classList.remove("is-invalid");
+  } else if (
+    // Si el correo tiene un @
+    element.value.split("@").length == 2 &&
+    element.value.split("@")[1].split(".").length == 2
+  ) {
+    element.classList.remove("is-invalid");
+    element.classList.add("is-valid");
+  } else {
+    // Si el correo no tiene @
+    element.classList.remove("is-valid");
+    element.classList.add("is-invalid");
+  }
+};
+
+let validarInputMensaje = (event) => {
+  // Verificar que no exceda los 500 characters
+  if (!event.target.value.length) {
+    event.target.classList.remove("is-valid");
+    event.target.classList.remove("is-invalid");
+  } else if (event.target.value.length > 500) {
+    event.target.classList.add("is-invalid");
+    event.target.classList.remove("is-valid");
+  } else {
+    event.target.classList.add("is-valid");
+    event.target.classList.remove("is-invalid");
+  }
+};
+
+let formularioOnInput = (event) => {
+  // Al introducir cosas en el Form se ocultan las alertas del formulario
+  form_alerts.classList.add("form_alerts_hide");
+  form_alerts.querySelector("DIV").classList.remove("alert-success");
+};
+
+let formularioOnSubmit = (event) => {
+  // Se cancela el refresh
+  event.preventDefault();
+
+  // Validar que todos los espacios están completos:
+  if (!form_nombre.value.length) form_nombre.classList.add("is-invalid");
+
+  // Validar el contenido del input de teléfono
+  validarInputTelefono({ target: form_telefono });
+  // if (! form_telefono.value.length ) // Opcional
+  //     form_telefono.classList.add("is-invalid");
+
+  // Validar el correo y invalidar si está vacío
+  validarInputCorreo({ target: form_email });
+  if (!form_email.value.length) form_email.classList.add("is-invalid");
+
+  if (!form_mensaje.value.length) form_mensaje.classList.add("is-invalid");
+
+  // Hacemos el post a través de fetch
+  if (
+    form_alerts.querySelector("DIV").classList.contains("alert-success") ||
+    formulario.querySelectorAll(".is-invalid").length // Si hay inputs inválidos
+  ) {
+    // Ya fue enviado el formulario o hay inputs inválidos, no hacer nada
+  }
+  // Enviar el formulario por primera vez
+  else
+    (async () => {
+      try {
+        let response = await fetch("post_form", {
+          method: "POST",
+          body: new FormData(event.target),
+        });
+        let data = await response.json();
+
+        // Notificar correcto POST
+        if (response.ok) {
+          // Success banner
+          form_alerts.classList.remove("form_alerts_hide");
+          form_alerts.querySelector("DIV").classList.remove("alert-danger");
+          form_alerts.querySelector("DIV").classList.add("alert-success");
+          form_alerts.querySelector("DIV").innerHTML = data.message;
+        } else {
+          // Notificar POST erróneo server-side
+          form_alerts.classList.remove("form_alerts_hide");
+          form_alerts.querySelector("DIV").classList.remove("alert-success");
+          form_alerts.querySelector("DIV").classList.add("alert-danger");
+          form_alerts.querySelector("DIV").innerHTML = data.message;
+        }
+      } catch (error) {
+        // Notificar POST erróneo por conectividad
+        console.error("Error: ", error);
+        form_alerts.classList.remove("form_alerts_hide");
+        form_alerts.querySelector("DIV").classList.remove("alert-success");
+        form_alerts.querySelector("DIV").classList.add("alert-danger");
+        form_alerts.querySelector("DIV").innerHTML =
+          "Formulario <strong>no enviado</strong> debido a error de conectividad.";
+      }
+    })();
+};
+
+let formularioOnReset = (event) => {
+  // Al ejecutar un reset se ocultan las alertas del formulario
+  formulario
+    .querySelectorAll(".is-valid")
+    .forEach((element) => element.classList.remove("is-valid"));
+  formulario
+    .querySelectorAll(".is-invalid")
+    .forEach((element) => element.classList.remove("is-invalid"));
+
+  form_alerts.classList.add("form_alerts_hide");
+  form_alerts.querySelector("DIV").classList.remove("alert-success");
+};
+
+////////////////////////////////////////////////////////////
+////////////////////////// Agregar los listener ////////////
+////////////////////////////////////////////////////////////
+
+form_nombre.addEventListener("input", validarInputNombre);
+
+form_telefono.addEventListener("input", validarInputTelefono);
+
+form_email.addEventListener("input", validarInputCorreo);
+
+form_mensaje.addEventListener("input", validarInputMensaje);
+
+formulario.addEventListener("input", formularioOnInput);
+
+formulario.addEventListener("submit", formularioOnSubmit);
+
+formulario.addEventListener("reset", formularioOnReset);

--- a/buses/contacto/static/contacto/js/main_contacto.js
+++ b/buses/contacto/static/contacto/js/main_contacto.js
@@ -64,7 +64,7 @@ let validarInputCorreo = (event) => {
   } else if (
     // Si el correo tiene un @
     element.value.split("@").length == 2 &&
-    element.value.split("@")[1].split(".").length == 2
+    element.value.split("@")[1].split(".").length > 2
   ) {
     element.classList.remove("is-invalid");
     element.classList.add("is-valid");

--- a/buses/contacto/templates/contacto.html
+++ b/buses/contacto/templates/contacto.html
@@ -1,6 +1,14 @@
 {% extends 'base.html'%}
 
+{% load static %}
+
 {% block page_title %} Contacto {% endblock %}
+
+{% block custom_header %}
+{# Aquí los estilos propios de la página de contacto#}
+
+<link rel="stylesheet" href="{% static 'contacto/css/formulario.css' %}">
+{% endblock %}
 
 {% block content %}
 
@@ -181,7 +189,7 @@
             </div>
             <div id="resp{{ pregunta.id }}" class="collapse" aria-labelledby="preg{{ pregunta.id }}" data-parent="#basicsAccordion">
               <div class="card-body px-0">
-                <p>{{ pregunta.respuesta }}</p>
+                  <p>{{ pregunta.respuesta }}</p>
               </div>
             </div>
           </div>
@@ -191,5 +199,13 @@
       </div>
     </div>
   </p>
- 
-{% endblock %}
+  
+  {% endblock %}
+
+  {% block custom_footer %}
+  {# Aquí el código JS exclusivo de la página de contactos #}
+
+  <!-- Main contacto -->
+  <script type="module" src="{% static 'contacto/js/main_contacto.js' %}" type="text/javascript"></script>
+
+  {% endblock %}

--- a/buses/contacto/templates/form.html
+++ b/buses/contacto/templates/form.html
@@ -1,36 +1,95 @@
-  {% if enviado %}
-  {{ notificacion }}
-  {% else %}
-  <form method="post">
-      {% csrf_token %}
-    <div class="form-group">
-      <label for="id_nombre">Nombre completo</label>
-      <input type="text" class="form-control" id="id_nombre" name="nombre" placeholder="Nombre completo" required>
+<form
+    method="post"
+    action="/post_form"
+    class="needs-validation"
+    novalidate
+>
+  {% csrf_token %}
+  <div class="form-group">
+    <label for="id_nombre">Nombre completo</label>
+    <input
+      type="text"
+      class="form-control"
+      id="id_nombre"
+      name="nombre"
+      placeholder="Nombre completo"
+      required
+    />
+    <div class="valid-feedback">
+        Luce muy bien
     </div>
-    <div class="form-group">
-        <label for="id_telefono">Teléfono</label>
-        <input type="text" class="form-control" id="id_telefono" name="telefono" placeholder="Teléfono (opcional)">
+    <div class="invalid-feedback">
+        Uhmm... algo no está bien :(
     </div>
-    <div class="form-group">
-      <label for="id_email">Correo electrónico</label>
-      <input type="email" class="form-control" id="id_email" name="email" aria-describedby="emailHelp" placeholder="ejemplo@dominio.com (opcional)" required>
-      <small id="emailHelp" class="form-text text-muted">A este correo electrónico llega la respuesta.</small>
+  </div>
+  <div class="form-group">
+    <label for="id_telefono">Teléfono</label>
+    <input
+      type="text"
+      class="form-control"
+      id="id_telefono"
+      name="telefono"
+      placeholder="Teléfono (opcional)"
+    />
+    <div class="valid-feedback">
+        Excelente!
     </div>
-    <div class="form-group">
-      <label for="id_asunto">Motivo de contacto</label>
-      <select class="form-control" id="id_asunto" name="asunto">
-        <option>Sugerencias de mejora</option>
-        <option>Objetos perdidos</option>
-        <option>Información general</option>
-        <option>Reclamos por servicio</option>
-        <option>Sugerencias para la página web</option>
-        <option>Otro</option>
-      </select>
+    <div class="invalid-feedback">
+        El número solo lleva números espacios/guiones y/o un único <strong>+</strong>
     </div>
-    <div class="form-group">
-      <label for="id_mensaje">Explicación</label>
-      <textarea class="form-control" id="id_mensaje" name="mensaje" rows="3"></textarea>
+  </div>
+  <div class="form-group">
+    <label for="id_email">Correo electrónico</label>
+    <input
+      type="email"
+      class="form-control"
+      id="id_email"
+      name="email"
+      aria-describedby="emailHelp"
+      placeholder="ejemplo@dominio.com"
+      required
+    />
+    <div class="valid-feedback">
+        Buen correo!
     </div>
+    <div class="invalid-feedback">
+        Este correo no parece válido :T
+    </div>
+    <small id="emailHelp" class="form-text text-muted"
+      >A este correo electrónico llega la respuesta.</small
+    >
+  </div>
+  <div class="form-group">
+    <label for="id_asunto">Motivo de contacto</label>
+    <select class="form-control" id="id_asunto" name="asunto">
+      <option>Sugerencias de mejora</option>
+      <option>Objetos perdidos</option>
+      <option>Información general</option>
+      <option>Reclamos por servicio</option>
+      <option>Sugerencias para la página web</option>
+      <option>Otro</option>
+    </select>
+  </div>
+  <div class="form-group">
+    <label for="id_mensaje">Explicación</label>
+    <textarea
+      class="form-control"
+      id="id_mensaje"
+      name="mensaje"
+      rows="3"
+    ></textarea>
+    <div class="valid-feedback">
+        Gracias!
+    </div>
+    <div class="invalid-feedback">
+        Por favor reducir el tamaño del mensaje a lo más importante, gracias.
+    </div>
+  </div>
+  <div class="d-flex justify-content-between">
+    <button class="btn btn-danger" type="reset">Limpiar</button>
     <button class="btn btn-primary" type="submit">Enviar</button>
-  </form>
-  {% endif %}
+  </div>
+  <div class="form_alerts form_alerts_hide">
+      <div class="alert" role="alert"></div>
+  </div>
+</form>

--- a/buses/contacto/templates/form.html
+++ b/buses/contacto/templates/form.html
@@ -32,7 +32,7 @@
       placeholder="Teléfono (opcional)"
     />
     <div class="valid-feedback">
-        Excelente!
+        ¡Excelente!
     </div>
     <div class="invalid-feedback">
         El número solo lleva números espacios/guiones y/o un único <strong>+</strong>
@@ -50,7 +50,7 @@
       required
     />
     <div class="valid-feedback">
-        Buen correo!
+        ¡Buen correo!
     </div>
     <div class="invalid-feedback">
         Este correo no parece válido :T
@@ -79,7 +79,7 @@
       rows="3"
     ></textarea>
     <div class="valid-feedback">
-        Gracias!
+        ¡Gracias!
     </div>
     <div class="invalid-feedback">
         Por favor reducir el tamaño del mensaje a lo más importante, gracias.

--- a/buses/contacto/urls.py
+++ b/buses/contacto/urls.py
@@ -3,5 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.contacto, name='contacto')
+    path('', views.contacto, name='contacto'),
+    path('post_form', views.post_contact_form, name='post_contact_form')
 ]

--- a/buses/contacto/views.py
+++ b/buses/contacto/views.py
@@ -30,14 +30,22 @@ def post_contact_form (request):
     try:
         telegram_token = settings.TELEGRAM_BOT_TOKEN
         telegram_chat_id = settings.TELEGRAM_ADMIN_GROUP
-        res = requests.get('https://api.telegram.org/bot' + str(telegram_token) + '/getMe')
+
+        res = requests.get(
+            "https://api.telegram.org/bot{}/getMe" \
+            .format(telegram_token)
+        )
+
         response = json.loads(res.text)
 
         # Comprobar que es el bot de tsg
         assert (response['result']['username'] == "tsgBusesBot")
-        res = requests.get('https://api.telegram.org/bot' + str(telegram_token) +
-                           '/sendMessage?chat_id='+str(telegram_chat_id)+
-                           '&text='+str(asunto)+"\n\n"+str(mensaje))
+
+        res = requests.get(
+            "https://api.telegram.org/bot{}/sendMessage?chat_id={}&text={}\n\n{}" \
+            .format(telegram_token, telegram_chat_id, asunto, mensaje)
+        )
+
         response = json.loads(res.text)
         print(response)
 

--- a/buses/contacto/views.py
+++ b/buses/contacto/views.py
@@ -3,6 +3,10 @@ from django.core.mail import send_mail, BadHeaderError
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.views.decorators.http import require_GET, require_POST
 
+from django.conf import settings
+import json
+import requests
+
 # Create your views here.
 
 from rutas.models import Agency
@@ -11,21 +15,41 @@ from .form import Formulario
 
 @require_POST
 def post_contact_form (request):
+
     formulario = Formulario(request.POST)
-    if formulario.is_valid():
-        nombre = formulario.cleaned_data['nombre']
-        email = formulario.cleaned_data['email']
-        asunto = formulario.cleaned_data['asunto']
-        mensaje = formulario.cleaned_data['mensaje']
-        mensaje = mensaje + "\nEnviado por el usuario: " +\
-            nombre + '[' + email + ']'
+    if not formulario.is_valid():
+        return JsonResponse(status=500, data={"message": "Ha ocurrido un error, por favor intente nuevamente, gracias."})
 
-        try: # FIXME: implementar correctamente la configuración de SMTP usando correo del administrador que está en base de datos
-            send_mail(asunto, mensaje, email, ['tsgdumbacc@gmail.com'])
-            # send_mail("Mensaje recibido", "Agredecemos su aporte.", 'tsgdumbacc@gmail.com', [email]) # TODO remove
+    nombre = formulario.cleaned_data['nombre']
+    email = formulario.cleaned_data['email']
+    asunto = formulario.cleaned_data['asunto']
+    mensaje = formulario.cleaned_data['mensaje']
+    mensaje = mensaje + "\n\nEnviado por el usuario: " +\
+        nombre + "\nCorreo: " + '[' + email + ']'
 
-        except BadHeaderError:
-            return JsonResponse(status=500, data={"message": "Ha ocurrido un error, por favor intente más tarde, gracias."})
+    try:
+        telegram_token = settings.TELEGRAM_BOT_TOKEN
+        telegram_chat_id = settings.TELEGRAM_ADMIN_GROUP
+        res = requests.get('https://api.telegram.org/bot' + str(telegram_token) + '/getMe')
+        response = json.loads(res.text)
+
+        # Comprobar que es el bot de tsg
+        assert (response['result']['username'] == "tsgBusesBot")
+        res = requests.get('https://api.telegram.org/bot' + str(telegram_token) +
+                           '/sendMessage?chat_id='+str(telegram_chat_id)+
+                           '&text='+str(asunto)+"\n\n"+str(mensaje))
+        response = json.loads(res.text)
+        print(response)
+
+    except:
+        print("No telegram bot interface")
+
+    try: # FIXME: implementar correctamente la configuración de SMTP usando correo del administrador que está en base de datos
+        send_mail(asunto, mensaje, email, ['tsgdumbacc@gmail.com'])
+        # send_mail("Mensaje recibido", "Agredecemos su aporte.", 'tsgdumbacc@gmail.com', [email]) # TODO remove
+
+    except BadHeaderError:
+        return JsonResponse(status=500, data={"message": "Ha ocurrido un error, por favor intente más tarde, gracias."})
 
     return JsonResponse(status=200, data={"message": '<i class="fas fa-info-circle"></i> Formulario <strong>enviado</strong> correctamente! Gracias!'})
 

--- a/buses/contacto/views.py
+++ b/buses/contacto/views.py
@@ -23,9 +23,15 @@ def post_contact_form (request):
     nombre = formulario.cleaned_data['nombre']
     email = formulario.cleaned_data['email']
     asunto = formulario.cleaned_data['asunto']
+    telefono = formulario.cleaned_data['telefono']
     mensaje = formulario.cleaned_data['mensaje']
-    mensaje = mensaje + "\n\nEnviado por el usuario: " +\
-        nombre + "\nCorreo: " + '[' + email + ']'
+
+    if telefono:
+        mensaje = "{}\n\nEnviado por el usuario: {}\nCorreo: [{}]\nTeléfono: {}"\
+        .format(mensaje, nombre, email, telefono)
+    else:
+        mensaje = "{}\n\nEnviado por el usuario: {}\nCorreo: [{}]"\
+        .format(mensaje, nombre, email)
 
     try:
         telegram_token = settings.TELEGRAM_BOT_TOKEN

--- a/buses/contacto/views.py
+++ b/buses/contacto/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.shortcuts import get_object_or_404, render, redirect
 from django.core.mail import send_mail, BadHeaderError
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
@@ -58,9 +59,14 @@ def post_contact_form (request):
     except:
         print("No telegram bot interface")
 
-    try: # FIXME: implementar correctamente la configuración de SMTP usando correo del administrador que está en base de datos
-        send_mail(asunto, mensaje, email, ['tsgdumbacc@gmail.com'])
-        # send_mail("Mensaje recibido", "Agredecemos su aporte.", 'tsgdumbacc@gmail.com', [email]) # TODO remove
+    try: # TODO agregar la cuenta oficial como CC
+        assert settings.EMAIL_HOST_USER
+        send_mail(asunto, mensaje, email, [settings.EMAIL_HOST_USER])
+        send_mail("Mensaje recibido", "Agredecemos su aporte.", settings.EMAIL_HOST_USER, [email])
+
+    except AssertionError:
+        # TODO notificar por medio del BotTelegram
+        return JsonResponse(status=500, data={"message": "Error de configuración, lo sentimos, trabajamos en resolverlo."})
 
     except BadHeaderError:
         return JsonResponse(status=500, data={"message": "Ha ocurrido un error, por favor intente más tarde, gracias."})

--- a/buses/contacto/views.py
+++ b/buses/contacto/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import get_object_or_404, render, redirect
 from django.core.mail import send_mail, BadHeaderError
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.views.decorators.http import require_GET, require_POST
 
 # Create your views here.
 
@@ -8,33 +9,31 @@ from rutas.models import Agency
 from .models import Pregunta
 from .form import Formulario
 
+@require_POST
+def post_contact_form (request):
+    formulario = Formulario(request.POST)
+    if formulario.is_valid():
+        nombre = formulario.cleaned_data['nombre']
+        email = formulario.cleaned_data['email']
+        asunto = formulario.cleaned_data['asunto']
+        mensaje = formulario.cleaned_data['mensaje']
+        mensaje = mensaje + "\nEnviado por el usuario: " +\
+            nombre + '[' + email + ']'
+
+        try: # FIXME: implementar correctamente la configuración de SMTP usando correo del administrador que está en base de datos
+            send_mail(asunto, mensaje, email, ['tsgdumbacc@gmail.com'])
+            # send_mail("Mensaje recibido", "Agredecemos su aporte.", 'tsgdumbacc@gmail.com', [email]) # TODO remove
+
+        except BadHeaderError:
+            return JsonResponse(status=500, data={"message": "Ha ocurrido un error, por favor intente más tarde, gracias."})
+
+    return JsonResponse(status=200, data={"message": '<i class="fas fa-info-circle"></i> Formulario <strong>enviado</strong> correctamente! Gracias!'})
+
+@require_GET
 def contacto(request):
-
-    # Estado del formulario
-    enviado = False
-
-    if request.method == 'GET':
-        formulario = Formulario()
-    else:
-        formulario = Formulario(request.POST)
-        if formulario.is_valid():
-            nombre = formulario.cleaned_data['nombre']
-            email = formulario.cleaned_data['email']
-            asunto = formulario.cleaned_data['asunto']
-            mensaje = formulario.cleaned_data['mensaje']
-            mensaje = mensaje + "\nEnviado por el usuario: " +\
-                nombre + '[' + email + ']'
-            try: # FIXME: implementar correctamente la configuración de SMTP usando correo del administrador que está en base de datos
-                send_mail(asunto, mensaje, email, ['tsgdumbacc@gmail.com'])
-                send_mail("Mensaje recibido", "Agredecemos su aporte.", 'tsgdumbacc@gmail.com', [email])
-            except BadHeaderError:
-                return HttpResponse('Configuración de correo inválida.')
-            enviado = True
-    
-    notificacion = "¡Listo! gracias por su mensaje" # FIXME: agregar mensaje de confirmación
-    
+    formulario = Formulario()
     empresa = get_object_or_404(Agency, agency_id='TSG')
-    
+
     preguntas = Pregunta.objects.all()
     antes = preguntas.filter(categoria = -1)
     durante = preguntas.filter(categoria = 0)
@@ -46,8 +45,6 @@ def contacto(request):
         'durante': durante,
         'despues': despues,
         'formulario': formulario,
-        'enviado': enviado,
-        'notificacion': notificacion,
     }
-    
+
     return render(request, 'contacto.html', contexto)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sqlparse
 pillow
 gunicorn
 shapeeditor
+requests


### PR DESCRIPTION
- [x] Ordenar el código HTML del formulario
- [x] Crear y linkear el CSS específico de la sección formulario 
- [x] Separar la lógica tras el POST y GET en las vistas de Python
- [x] Usar Fetch para postear el formulario sin hacer refresh
- [x] Crear una sección de alerta que se muestra al enviar el formulario o fallar el envío
- [x] Oculta  alertas al realizar nueva edición del formulario
- [x] Crear un event listener por cada input para verificación activa de datos
- [x] Verificar el código retorno del backend para notificar errores server-side
- [x] Quitar la actual verificación básica por HTML ya que es estéticamente fea e insuficiente


Los formularios de contacto modernos verifican los datos en frontend antes de enviarlos al servidor, para esto por ejemplo se puede crear una función o utilizar una de las muchas que ya existen para quitar los guiones y espacios a los números de teléfono, así como verificar que el primer char sea un número o un signo +, verificar que todos los chars del string con excepción del primero sean números.

_OnChange_ del input verificar y si el dato está erróneo colocar un alert o cambiar el estilo del input para denotar error.