### PR TITLE
Para iniciar quitar-semanasanta.

### DIFF
--- a/buses/buses/urls.py
+++ b/buses/buses/urls.py
@@ -15,7 +15,6 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-from django.conf.urls import url
 from django.conf import settings
 from django.conf.urls.static import static
 

--- a/buses/inicio/templates/index.html
+++ b/buses/inicio/templates/index.html
@@ -18,12 +18,6 @@
         <p><div class="alert alert-soft-secondary" role="alert">Servimos a comunidades de la región Caraigres en los cantones de <br> Acosta y Aserrí en la provincia de San José en Costa Rica</div></p> 
       </div>
 
-
-  <!-- Alerta sobre Semana Santa 2022 -->
-  <p class="text-center">
-    <span class="divider divider-text">Horario especial&nbsp;<i class="fa fa-cross"></i>&nbsp;<strong>Semana Santa</strong></span>
-  </p>
-
       <!-- Links de las páginas de cada ruta -->
 
       <div class="row justify-content-center">

--- a/buses/inicio/templates/index.html
+++ b/buses/inicio/templates/index.html
@@ -14,7 +14,7 @@
     <div class="container space-top-3 space-bottom-3 position-relative z-index-2">
       <div class="w-md-80 w-lg-60 text-center mx-md-auto mb-5 mb-md-9">
         <h1>Transportes San&nbsp;Gabriel</h1>
-        <p class="lead">Esta es la nueva página web con información del servicio de transporte público de nuestras rutas de autobús.</p>
+        <p class="lead">Información del servicio de transporte público <br> de nuestras rutas de autobús.</p>
         <p><div class="alert alert-soft-secondary" role="alert">Servimos a comunidades de la región Caraigres en los cantones de <br> Acosta y Aserrí en la provincia de San José en Costa Rica</div></p> 
       </div>
 
@@ -67,23 +67,21 @@
   <!-- Alerta sobre Google Maps -->
   <div class="alert alert-soft-info" role="alert">
     <p>
-        <ol class="fa-ul">
-            <li><span class="fa-li"><i class="fab fa-google"></i></span> <strong>¡Ya estamos en <span style="color: #4885ed;">G</span><a style="color: #db3236;">o</a><a style="color: #f4c20d;">o</a><a style="color: #4885ed;">g</a><a style="color: #3cba54;">l</a><a style="color: #db3236;">e</a> <a href="http://maps.google.com/">Maps</a>!</strong></li>
-            <ol class="fa-ul">
-              <li><span class="fa-li"><i class="fas fa-map-marked-alt"></i></span> Somos de las primeras agencias de transporte del país con información de horarios, tarifas y más en esta aplicación.</li>
-          </ol>
-        </ol>
+      <ol class="fa-ul">
+          <li><span class="fa-li"><i class="fab fa-google"></i></span> <strong>¡Búsquenos en la aplicación de <span style="color: #4885ed;">G</span><a style="color: #db3236;">o</a><a style="color: #f4c20d;">o</a><a style="color: #4885ed;">g</a><a style="color: #3cba54;">l</a><a style="color: #db3236;">e</a> <a href="http://maps.google.com/">Maps</a>!</strong></li>
+      </ol>
     </p>  
   </div>
 
-  <!-- Alerta sobre COVID-19 -->
+  <!-- Alerta sobre COVID-19
   <div class="alert alert-soft-danger" role="alert">
     <p>
-        <ol class="fa-ul">
-            <li><span class="fa-li"><i class="fas fa-viruses"></i></span>Hay <a href="/covid19">restricciones sanitarias <i class="fas fa-info-circle"></i></a> vigentes para el uso del transporte público por la emergencia de COVID-19.</li>
-        </ol>
+      <ol class="fa-ul">
+          <li><span class="fa-li"><i class="fas fa-viruses"></i></span>Hay <a href="/covid19">restricciones sanitarias <i class="fas fa-info-circle"></i></a> vigentes para el uso del transporte público por la emergencia de COVID-19.</li>
+      </ol>
     </p>  
-  </div>
+  </div> 
+  -->
 
 
 <section>

--- a/buses/rutas/templates/ruta.html
+++ b/buses/rutas/templates/ruta.html
@@ -98,139 +98,29 @@ NOTA: TODO: Este div no tiene terminación, hay que hacer que cierre consistente
         </p>  
     </div>
     {% endif %}
-    
-    <!-- Alerta sobre Google Maps -->
-    <div class="alert alert-soft-info" role="alert">
-        <p>
-            <ol class="fa-ul">
-                <li><span class="fa-li"><i class="fab fa-google"></i></span> <strong>¡Ya estamos en <span style="color: #4885ed;">G</span><a style="color: #db3236;">o</a><a style="color: #f4c20d;">o</a><a style="color: #4885ed;">g</a><a style="color: #3cba54;">l</a><a style="color: #db3236;">e</a> <a href="http://maps.google.com/">Maps</a>!</strong></li>
-                <ol class="fa-ul">
-                <li><span class="fa-li"><i class="fas fa-map-marked-alt"></i></span> Somos de las primeras agencias de transporte del país con información de horarios, tarifas y más en esta aplicación.</li>
-            </ol>
-            </ol>
-        </p>  
-    </div>
-    
-    <!-- Alerta sobre COVID-19 -->
-    <div class="alert alert-soft-danger" role="alert">
-        <p>
-            <ol class="fa-ul">
-                <li><span class="fa-li"><i class="fas fa-viruses"></i></span>Hay <a href="/covid19">restricciones sanitarias <i class="fas fa-info-circle"></i></a> vigentes para el uso del transporte público por la emergencia de COVID-19.</li>
-            </ol>
-        </p>  
-    </div>
 
 <!-- Tabla de horario -->
 
 <section id="horario">
 
     <hr>
-    <h2><i class="fas fa-clock color-ruta"></i> Horario</h2>
+    <h2><i class="fas fa-clock color-ruta"></i> Horarios</h2>
 
     <!-- Nota sobre el horario de salida -->
     <div class="alert alert-soft-secondary" role="alert">
         <p>
             <ol class="fa-ul">
-                <li><span class="fa-li"><i class="fas fa-info-circle"></i></span>La hora del viaje hacia San José es en la parada de {{ route.short_name }} centro.
-                    Los buses salen 15 minutos antes desde
+                <li><span class="fa-li"><i class="fas fa-info-circle"></i></span>La hora del viaje hacia San José es en la parada de <strong>{{ route.short_name }} centro</strong>.
+                    Los buses salen <strong>15 minutos antes</strong> desde
                     {% if route.short_name == 'Acosta' %}
                         San Luis o Turrujal, según se indica
                     {% else %}
                         Los Mangos
                     {% endif %}
                     (ver lista de <a href="#paradas">paradas autorizadas</a>).</li>
-                    <li><span class="fa-li"><i class="fas fa-calendar-check"></i></span>Horario actualizado el <span class="text-lowercase font-weight-bold">{{ informacion.start_date }}</span>.</li>
             </ol>
         </p>
     </div>
-
-    <!-- Horario especial de Semana Santa -->
-    <div class="alert alert-soft-secondary" role="alert">
-        <div>
-            <button class="btn btn-danger btn-sm" type="button" data-toggle="collapse" data-target="#semanasanta" aria-expanded="false" aria-controls="semanasanta">
-                <i class="fa fa-cross"></i> &nbsp; Ver horario Semana Santa
-            </button>
-        </div>
-
-        <div class="collapse" id="semanasanta">
-            <hr>
-            <p>
-                Por motivo de la celebración de la Semana Santa, informamos que en los días <strong>Jueves Santo</strong> (14 de abril de 2022) y <strong>Viernes Santo</strong> (15 de abril de 2022) tendremos el siguiente horario: 
-                <h4 class="alert-heading">San Luis / Turrujal &nbsp;<i class="fa fa-bus"></i>&nbsp; San José</h4>
-                <table class="table table-thead-bordered">
-                    <thead class="thead-light">
-                      <tr>
-                        <th scope="col">San Luis / Turrujal</th>
-                        <th scope="col">Centro de Acosta</th>
-                        <th scope="col">San José</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <th scope="row">4:15 AM</th>
-                        <td>4:30 AM</td>
-                        <td>6:30 AM</td>
-                      </tr>
-                      <tr>
-                        <th scope="row">8:15 AM</th>
-                        <td>8:30 AM</td>
-                        <td>10:30 AM</td>
-                      </tr>
-                      <tr>
-                        <th scope="row">12:15 PM</th>
-                        <td>12:30 PM</td>
-                        <td>2:30 PM</td>
-                      </tr>
-                      <tr>
-                        <th scope="row">4:15 PM</th>
-                        <td>4:30 PM</td>
-                        <td>6:30 PM</td>
-                      </tr>
-                      <tr>
-                        <th scope="row">8:15 PM</th>
-                        <td>8:30 PM</td>
-                        <td>10:30 PM</td>
-                      </tr>
-                    </tbody>
-                </table>
-                <p class="small">El bus de Turrujal hace transbordo al bus de San Luis en el centro de Acosta.</p>
-                <hr>
-                <h4 class="alert-heading">San Gabriel &nbsp;<i class="fa fa-bus"></i>&nbsp; San José</h4>
-                <table class="table table-thead-bordered">
-                    <thead class="thead-light">
-                      <tr>
-                        <th scope="col">Los Mangos</th>
-                        <th scope="col">San Gabriel</th>
-                        <th scope="col">San José</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <th scope="row">4:45 AM</th>
-                        <td>5:00 AM</td>
-                        <td>7:30 AM</td>
-                      </tr>
-                      <tr>
-                        <th scope="row">9:00 AM</th>
-                        <td>9:15 AM</td>
-                        <td>11:30 AM</td>
-                      </tr>
-                      <tr>
-                        <th scope="row">12:30 PM</th>
-                        <td>12:45 PM</td>
-                        <td>3:30 PM</td>
-                      </tr>
-                      <tr>
-                        <th scope="row">7:15 PM</th>
-                        <td>7:30 PM</td>
-                        <td>10:30 PM</td>
-                      </tr>
-                    </tbody>
-                </table>
-            </p>
-        </div>
-    </div>
-    
 
     <!-- Tabla de horarios-->
     <p>
@@ -342,10 +232,11 @@ NOTA: TODO: Este div no tiene terminación, hay que hacer que cierre consistente
         </button>
     </div>
 
-    <!-- Datos de GTFS y Google Maps -->
+    <!-- Datos de actualización de horarios, GTFS y Google Maps -->
     <p>
         <div class="small">
             <ol class="fa-ul">
+                <li><span class="fa-li"><i class="fas fa-calendar-check"></i></span>Último cambio de horarios el <span class="text-lowercase font-weight-bold">{{ informacion.start_date }}</span></li>
                 <li><span class="fa-li"><i class="fas fa-database"></i></span>Datos de <a href="/gtfs/">GTFS</a></li>
                 <li><span class="fa-li"><i class="fab fa-google"></i></span>Ver en <a href="https://www.google.com/maps/@9.7985547,-84.1334907,14.81z" target="_blank">Google Maps</a></li>
             </ol>
@@ -387,20 +278,28 @@ NOTA: TODO: Este div no tiene terminación, hay que hacer que cierre consistente
     <hr>
     <h2><i class="fas fa-ticket-alt color-ruta"></i> Tarifas</h2>
 
-    <p>Precios autorizados por <a href="https://aresep.go.cr/autobus/tarifas" target="_blank">ARESEP</a>. Más información <a href="/tarifas">aquí</a>.</p>
-
     <!-- Nota sobre "solo efectivo" -->
     <div class="alert alert-soft-secondary" role="alert">
         <p>
             <ol class="fa-ul">
                 <li><span class="fa-li"><i class="fas fa-money-bill-wave"></i></span>
-                    Únicamente son posibles los pagos <strong>en efectivo</strong> a bordo del autobús.
+                    Pagos a bordo en efectivo.
                 </li>
             </ol>
         </p>
     </div>
 
     {% include "tarifas-cards.html" %}
+
+    <!-- Datos de actualización de tarifas, autorización de ARESEP -->
+    <p>
+        <div class="small">
+            <ol class="fa-ul">
+                <li><span class="fa-li"><i class="fas fa-calendar-check"></i></span>Último cambio de tarifas el <strong>8 de marzo de 2022</strong></li>
+                <li><span class="fa-li"><i class="fas fa-balance-scale"></i></span>Precios autorizados por <a href="https://aresep.go.cr/autobus/tarifas" target="_blank">ARESEP</a></li>
+             </ol>
+        </div>
+    </p>
 
 </section>
 
@@ -427,7 +326,7 @@ NOTA: TODO: Este div no tiene terminación, hay que hacer que cierre consistente
     <!-- Información de la terminal en San José -->
     <div class="card card-bordered mb-8 mx-auto" style="max-width: 540px;">
         <div class="card-body">
-            <h5 class="card-title">Terminal en San&nbsp;José</h5>
+            <h4 class="card-title">Terminal en San&nbsp;José</h4>
               <ol class="fa-ul">
                 <li><span class="fa-li"><i class="far fa-map"></i></span>Calle <strong>7</strong>, entre avenidas <strong>10</strong> y <strong>12.</strong></li>
                 <li><span class="fa-li"><i class="fas fa-location-arrow"></i></span>200 metros sur de la esquina sureste del Parque de las Garantías Sociales.</li>
@@ -549,7 +448,7 @@ NOTA: TODO: Este div no tiene terminación, hay que hacer que cierre consistente
 <p>
     <div class="card borde-color-ruta">
         <div class="card-body text-center">
-            Esta ruta se identifica en los rótulos de los autobuses y en mapas con el color
+            Esta ruta se identifica con el color
             {% if route.short_name == 'Acosta' %}
             <strong class="color-sanluis">naranja criolla</strong> (San Luis) y <strong class="color-turrujal">rojo mandarina</strong> (Turrujal).
             {% else %}

--- a/buses/static/base.html
+++ b/buses/static/base.html
@@ -175,17 +175,17 @@
                   </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link media" href="mailto:correo@tsgcr.com">
+                  <a class="nav-link media" href="mailto:transgabriel@ice.co.cr">
                       <span class="media">
                         <span class="fas fa-envelope mt-1 mr-2"></span>
                         <span class="media-body">
-                          correo@tsgcr.com
+                          transgabriel@ice.co.cr
                         </span>
                       </span>
                   </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link media" href="mailto:correo@tsgcr.com">
+                  <a class="nav-link media" href="mailto:transgabriel@ice.co.cr">
                       <span class="media">
                         <span class="fas fa-clock mt-1 mr-2"></span>
                         <span class="media-body">
@@ -266,7 +266,7 @@
           <!-- Copyright -->
           <div class="w-md-75 text-lg-center mx-lg-auto">
             <p class="text-white opacity-sm">Esta página utiliza <a class="font-weight-bold text-white" href="/gtfs/">GTFS</a>, un estándar de datos abiertos para el transporte público.</p>
-            <p class="text-white opacity-sm small">&copy; Transportes San Gabriel, 2021.</p>
+            <p class="text-white opacity-sm small">&copy; Transportes San Gabriel, 2022.</p>
           </div>
           <!-- End Copyright -->
         </div>


### PR DESCRIPTION
Eliminar el HTML para el aviso de Semana Santa (el que causó el desastre).